### PR TITLE
Main+Connection: Use RwLock instead of Mutex

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -109,7 +109,7 @@ impl KeyValueStore {
         Ok(())
     }
 
-    fn handle_get_request(&mut self, buf: &[u8; 1024]) -> (String, String) {
+    fn handle_get_request(&self, buf: &[u8; 1024]) -> (String, String) {
         let key = match parse_key_from_request(buf) {
             Ok(key) => key,
             Err(_) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 use clap::Parser;
-use skv::connection::KeyValueStore;
+use skv::connection::{self, KeyValueStore, RequestType};
 use skv::thread::ThreadPool;
 use std::{
     error::Error,
     net::TcpListener,
-    sync::{Arc, Mutex},
+    sync::{Arc, RwLock},
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -18,19 +18,38 @@ fn main() -> Result<(), Box<dyn Error>> {
             )
         });
 
-    let key_value_store = Arc::new(Mutex::new(KeyValueStore::new()));
+    let key_value_store = Arc::new(RwLock::new(KeyValueStore::new()));
 
     let thread_pool = ThreadPool::new(4);
 
     for stream in listener.incoming() {
         let stream = stream.unwrap();
 
+        let buf = connection::buf_from_stream(&stream)?;
+        connection::verify_request(&buf)?;
+        let request_type = connection::request_type(&buf);
+
         let kv_store = Arc::clone(&key_value_store);
         thread_pool.execute(move || {
-            match kv_store.lock().unwrap().handle_request(stream) {
+            let (status_line, body) = match request_type {
+                RequestType::Get => kv_store
+                    .read()
+                    .expect("Failed to acquire read lock for get request.")
+                    .handle_get_request(&buf),
+                RequestType::Put => kv_store
+                    .write()
+                    .expect("Failed to acquire write lock for PUT request.")
+                    .handle_put_request(&buf),
+                RequestType::Delete => kv_store
+                    .write()
+                    .expect("Failed to acquire write lock for DELETE request.")
+                    .handle_put_request(&buf),
+                RequestType::Unknown(mesg) => mesg,
+            };
+            match connection::write_stream(&stream, status_line, body) {
                 Ok(_) => (),
-                Err(e) => eprintln!("Error, try again: {}", e),
-            }
+                Err(e) => eprintln!("Error encountered: {}", e),
+            };
         });
     }
 


### PR DESCRIPTION
This allows for non-blocking reads of the KeyValueStore but blocking PUT
and DELETE requests. No more mutex that was ruining the whole point of concurrency.